### PR TITLE
Prevent resolution to incompatible angular version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.3.0",
+    "angular": "<1.4.0",
     "angular-animate": "~1.3.0",
     "angular-cookies": "~1.3.0",
     "angular-sanitize": "~1.3.0",


### PR DESCRIPTION
Angular version >= 1.4.0 break the OMD angular application.
Without restricting the version, the resolution process is
not deterministic.
