### PR TITLE
III-2939 Add api key to place suggestions request

### DIFF
--- a/dist/udb3-angular.js
+++ b/dist/udb3-angular.js
@@ -2342,6 +2342,9 @@ function CityAutocomplete($q, $http, appConfig, UdbPlace, jsonLDLangFilter) {
     if (placesApi === 'sapi3') {
       url = appConfig.baseUrl + 'places/';
       config = {
+        headers: {
+          'X-Api-Key': _.get(appConfig, 'apiKey')
+        },
         params: {
           'postalCode': zipcode,
           'addressCountry': country,
@@ -2397,6 +2400,9 @@ function CityAutocomplete($q, $http, appConfig, UdbPlace, jsonLDLangFilter) {
     if (placesApi === 'sapi3') {
       url = appConfig.baseUrl + 'places/';
       config = {
+        headers: {
+          'X-Api-Key': _.get(appConfig, 'apiKey')
+        },
         params: {
           'q': 'address.\\*.addressLocality:' + city,
           'addressCountry': country,

--- a/src/core/city-autocomplete.service.js
+++ b/src/core/city-autocomplete.service.js
@@ -37,6 +37,9 @@ function CityAutocomplete($q, $http, appConfig, UdbPlace, jsonLDLangFilter) {
     if (placesApi === 'sapi3') {
       url = appConfig.baseUrl + 'places/';
       config = {
+        headers: {
+          'X-Api-Key': _.get(appConfig, 'apiKey')
+        },
         params: {
           'postalCode': zipcode,
           'addressCountry': country,
@@ -92,6 +95,9 @@ function CityAutocomplete($q, $http, appConfig, UdbPlace, jsonLDLangFilter) {
     if (placesApi === 'sapi3') {
       url = appConfig.baseUrl + 'places/';
       config = {
+        headers: {
+          'X-Api-Key': _.get(appConfig, 'apiKey')
+        },
         params: {
           'q': 'address.\\*.addressLocality:' + city,
           'addressCountry': country,


### PR DESCRIPTION
As reported by Stan in https://jira.uitdatabank.be/browse/III-2939 this request was failing on acceptance because it's missing an API key. Locally this requirement is disabled by default for easier testing, so that's why we didn't notice this.