### PR TITLE
Raise saved queries limit to 10

### DIFF
--- a/src/search/components/search-bar.directive.js
+++ b/src/search/components/search-bar.directive.js
@@ -12,6 +12,8 @@ angular
 
 /* @ngInject */
 function udbSearchBar(searchHelper, $rootScope, $uibModal, $translate, savedSearchesService) {
+  const LIMIT_SAVED_SEARCHES = 10;
+
   return {
     templateUrl: 'templates/search-bar.directive.html',
     restrict: 'E',
@@ -96,12 +98,12 @@ function udbSearchBar(searchHelper, $rootScope, $uibModal, $translate, savedSear
       }
 
       /**
-       * Show the first 5 items from a list of saved searches.
+       * Show the first 10 items from a list of saved searches.
        *
        * @param {Object[]} savedSearches
        */
       function showSavedSearches(savedSearches) {
-        searchBar.savedSearches = _.take(savedSearches, 5);
+        searchBar.savedSearches = _.take(savedSearches, LIMIT_SAVED_SEARCHES);
       }
 
       savedSearchesService


### PR DESCRIPTION
### Changed
Because ownership queries are now automaticly added, it is easy to go above the limit of 5, let us raise the saved query limit list to 10 saved queries

---
Ticket: https://jira.publiq.be/browse/III-6726
